### PR TITLE
added line numbers for syntax error in code cells + fix small typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Any code cells that do not constitute valid Python will report a syntax error
 for the corrisponding cell and will not undergo the check. The use of Ipython
 magics such as `%timeit` and `%run` will trigger a syntax error in the
 absence of an `ipython` installation. Conversely, if `ipython` is installed,
-the magics will be deemed valid Python allowing those cells to be checked
+the magics will be deemed valid Python, allowing those cells to be checked
 (other syntax errors not withstanding), but will only pass the check if 
 function calls and attributes are allowed. 
 


### PR DESCRIPTION
Had spotted a couple of typos, and improved the doc string for `get_line` as well as added the line numbers (relative to cells) indicating where the syntax error had occured.