### PR TITLE
Transform each cell in read_notebook

### DIFF
--- a/allowed.py
+++ b/allowed.py
@@ -544,11 +544,9 @@ def read_notebook(file_contents: str) -> tuple[str, list, list]:
             try:
                 if IPYTHON_INSTALLED:
                     cell_source = Transformer().transform_cell(cell_source)
-                    ast.parse(cell_source)
-                else:
-                    ast.parse(cell_source)
+                ast.parse(cell_source)
                 source_list.append(cell_source)
-                for cell_line_num in range(1, len(cell["source"]) + 1):
+                for cell_line_num in range(1, len(cell_source.split("\n")) + 1):
                     line_cell_map.append((cell_num, cell_line_num))
             except SyntaxError as error:
                 errors.append((cell_num, error.lineno, SYNTAX_MSG))

--- a/allowed.py
+++ b/allowed.py
@@ -540,23 +540,19 @@ def read_notebook(file_contents: str) -> tuple[str, list, list]:
     for cell in notebook["cells"]:
         if cell["cell_type"] == "code":
             cell_num += 1
-            cell_lines = cell["source"]
-            cell_lines[-1] += "\n"
-            cell_source = "".join(cell_lines)
+            cell_source = "".join(cell["source"])
             try:
                 if IPYTHON_INSTALLED:
-                    ast.parse(Transformer().transform_cell(cell_source))
+                    cell_source = Transformer().transform_cell(cell_source)
+                    ast.parse(cell_source)
                 else:
                     ast.parse(cell_source)
                 source_list.append(cell_source)
-                for cell_line_num in range(1, len(cell_lines) + 1):
+                for cell_line_num in range(1, len(cell["source"]) + 1):
                     line_cell_map.append((cell_num, cell_line_num))
             except SyntaxError as error:
                 errors.append((cell_num, error.lineno, SYNTAX_MSG))
-    if IPYTHON_INSTALLED:
-        source_str = Transformer().transform_cell("".join(source_list))
-    else:
-        source_str = "".join(source_list)
+    source_str = "\n".join(source_list)
     return source_str, line_cell_map, errors
 
 

--- a/sample.ipynb
+++ b/sample.ipynb
@@ -217,7 +217,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.10.10 (main, Mar  5 2023, 22:26:53) [GCC 12.2.1 20230201]"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/sample.ipynb
+++ b/sample.ipynb
@@ -18,9 +18,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "incomplete input (2567827985.py, line 2)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  Cell \u001b[0;32mIn[2], line 2\u001b[0;36m\u001b[0m\n\u001b[0;31m    x = (5, # missing )\u001b[0m\n\u001b[0m                       ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m incomplete input\n"
+     ]
+    }
+   ],
    "source": [
     "[x % 2 for x in range(10)]\n",
     "x = (5, # missing )"
@@ -36,9 +45,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 not positive\n",
+      "1 not prime\n",
+      "2 prime\n",
+      "3 prime\n",
+      "4 not prime\n",
+      "5 prime\n",
+      "6 not prime\n",
+      "7 prime\n",
+      "8 not prime\n",
+      "9 not prime\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"Sample code to test the checker.\"\"\"\n",
     "\n",
@@ -69,6 +95,45 @@
     "        print(n, \"prime\" if is_prime(n) else \"not prime\")\n",
     "    except AssertionError:\n",
     "        print(n, \"not positive\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next cell has a cell magic (starting with `%%`). If IPython is installed,\n",
+    "the cell will be transformed i.e. changed into valid Python.  \n",
+    "\n",
+    "In practice, for cell magics, this means any code following the magic will be\n",
+    "added as the second parameter to a `get_ipython().run_cell_magic()` method. If IPython is\n",
+    "not installed, the cell is considered invalid Python and will not be checked. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture output\n",
+    "\n",
+    "FIRST = 5\n",
+    "odd = odd_numbers(FIRST)\n",
+    "run_time = %timeit -q -o -r 3 -n 100 odd_numbers(FIRST)\n",
+    "print(f\"first {FIRST} odd numbers: {odd}\")\n",
+    "if odd.count(2) == 1:\n",
+    "    print(\"2 is considered odd: that's odd!\")\n",
+    "print(\"last odd generated:\", odd.pop())\n",
+    "\n",
+    "print(\"2^6 =\", 1 << 6)\n",
+    "print(\"Euler number e =\", math.e)\n",
+    "if type(odd_numbers) == types.FunctionType:\n",
+    "    print(\"odd_numbers is a function\")\n",
+    "\n",
+    "\n",
+    "x = 5\n",
+    "x = \"five\""
    ]
   },
   {
@@ -111,42 +176,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The next cell has a cell magic (starting with `%%`), and \n",
-    "a line magic within an assignment. Again, both are ignored \n",
-    "if IPython is installed, otherwise the cell is considered \n",
-    "invalid Python and not checked. \n"
+    "The next cell contains a line magic with an assignment. Again, this will be\n",
+    "ignored if IPython is installed, otherwise the cell is considered invalid\n",
+    "Python and not checked."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4.899999999974369e-05\n"
+     ]
+    }
+   ],
    "source": [
-    "%%capture output\n",
-    "\n",
-    "FIRST = 5\n",
-    "odd = odd_numbers(FIRST)\n",
-    "run_time = %timeit -q -o -r 3 -n 100 odd_numbers(FIRST)\n",
-    "print(f\"first {FIRST} odd numbers: {odd}\")\n",
-    "if odd.count(2) == 1:\n",
-    "    print(\"2 is considered odd: that's odd!\")\n",
-    "print(\"last odd generated:\", odd.pop())\n",
-    "\n",
-    "print(\"2^6 =\", 1 << 6)\n",
-    "print(\"Euler number e =\", math.e)\n",
-    "if type(odd_numbers) == types.FunctionType:\n",
-    "    print(\"odd_numbers is a function\")\n",
-    "\n",
-    "\n",
-    "x = 5\n",
-    "x = \"five\""
+    "run_time = %timeit -q -o -r 3 -n 100 is_prime(7001) \n",
+    "random_att = choice(dir(run_time))\n",
+    "print(getattr(run_time, random_att))"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "env",
+   "display_name": "dsa-ou",
    "language": "python",
    "name": "python3"
   },
@@ -165,7 +222,7 @@
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "8cee12ad2512558cdc79ba90299b13d726dd4d1e1af5c2af4af5b58f6d7a985d"
+    "hash": "49205d58e121ab1f37971b193f92e95bfb911194d7bd72e3b8eb85a1a70cf18d"
    }
   }
  },


### PR DESCRIPTION
I have made most of the relevant comments in #24. It was a bit of a face palm moment and seems so obvious with hindsight. This is the version that skips cells with "cell magics" (or at least turns them into function calls with large arguments) I also removed the `cell_lines` variable since it seems redundant (nothing to do with the fix though) . I have done some tests, but as I was saying in #24 the output for `sample.ipynb` is now different: most of the code in cell 4 is not checked as it it turned into a `run_cell_magic` call.