### PR TITLE
Fix #32: run under python > 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,22 @@
 # Changelog
 
 This file documents notable changes to this project.
+Changes to the documentation are not listed.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 with an additional 'Development' section for changes that don't affect users.
 This project does *not* adhere to [Semantic Versioning](https://semver.org).
 
-<!-- Within each release:
-### Added
-### Changed
-### Deprecated
-### Removed
-### Fixed
-### Security -->
+<!-- Per release: Added / Changed / Deprecated / Removed / Fixed / Security -->
 
 ## [Unreleased](https://github.com/dsa-ou/allowed/compare/v1.2.1...HEAD)
 These changes are in the GitHub repository but not on [PyPI](https://pypi.org/project/allowed).
 
 ### Added
-- option `-V` / `--version`: displays the version number and exits
+- option `-V` / `--version`: display the version number and exit
 - option `-f` / `--first`: for each file, only report the first of each construct
-- this change log
+
+### Changed
+- run under Python > 3.10
 
 ### Fixed
 - locale encoding on Windows can't read UTF-8: use UTF-8; replace characters that lead to errors
@@ -28,6 +25,7 @@ These changes are in the GitHub repository but not on [PyPI](https://pypi.org/pr
 
 ### Development
 - improve tests: process a folder, use `-f`, report each construct once per line
+- move ipython and pytype to development dependencies
 
 ## [1.2.1](https://github.com/dsa-ou/allowed/compare/v1.2b1...v1.2.1) - 2024-02-10
 The 1.2 version on PyPI doesn't include a fix to the usage message.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 install:
-	poetry install --extras "all"
+	poetry install
 
 update:
 	poetry update

--- a/allowed/allowed.py
+++ b/allowed/allowed.py
@@ -1,6 +1,6 @@
 """Check that Python and notebook files only use the allowed constructs."""
 
-__version__ = "1.3dev6"   # same as in pyproject.toml
+__version__ = "1.3dev7"   # same as in pyproject.toml
 
 import argparse
 import ast
@@ -10,17 +10,13 @@ import re
 import sys
 from pathlib import Path
 
-PYTHON_VERSION = sys.version_info[:2]
-if (3, 7) <= PYTHON_VERSION <= (3, 10):
-    try:
-        import pytype
-        from pytype.tools.annotate_ast import annotate_ast
+try:
+    import pytype
+    from pytype.tools.annotate_ast import annotate_ast
 
-        PYTYPE_OPTIONS = pytype.config.Options.create(python_version=PYTHON_VERSION)
-        PYTYPE_INSTALLED = True
-    except ImportError:
-        PYTYPE_INSTALLED = False
-else:
+    PYTYPE_OPTIONS = pytype.config.Options.create(python_version=(3,10))
+    PYTYPE_INSTALLED = True
+except ImportError:
     PYTYPE_INSTALLED = False
 try:
     from IPython.core.inputtransformer2 import TransformerManager as Transformer
@@ -28,7 +24,6 @@ try:
     IPYTHON_INSTALLED = True
 except ImportError:
     IPYTHON_INSTALLED = False
-
 
 # ----- Python's Abstract Syntax Tree (AST) -----
 
@@ -583,9 +578,6 @@ def read_notebook(file_contents: str) -> tuple[str, list, list]:
 def main() -> None:
     """Implement the CLI."""
     global FILE_UNIT, LANGUAGE, IMPORTS, METHODS
-
-    if PYTHON_VERSION < (3, 10):
-        sys.exit("error: can't check files (need Python 3.10 or higher)")
 
     argparser = argparse.ArgumentParser(
         prog="allowed",

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,27 +1,69 @@
 ## Installation
 
-`allowed` requires Python 3.10. Type `python3.10 -V` in a terminal to check if you have it.
-If you haven't it, [install it](https://www.python.org/downloads/release/python-31011/).
+If your IT administrator or instructor has created an environment for your course,
+with `allowed` installed, then you may skip this section.
 
+### Preparation
+1. Open a Linux/macOS terminal or Windows PowerShell,
+   in order to enter the commands given in these instructions.
+2. Enter `python -V` to check the version you have installed.
+3. If it's 3.9 or earlier, [download and install](https://www.python.org/downloads)
+   the latest version.
+
+### Virtual environments
 Like any other Python package, `allowed` can be installed in your default global environment,
-but should preferably be installed in a new or existing
-[virtual environment](https://realpython.com/python-virtual-environments-a-primer/)
-created with Python 3.10.
-Once the virtual environment is activated, type _one_ of the following:
-1. `pip install allowed` if you only need to
-   check Python files and Jupyter notebooks with Python code
-2. `pip install 'allowed[pytype]'` if you also want to
-   check method calls (as explained in the next section)
-3. `pip install 'allowed[ipython]'` if you want to
-   check notebook cells that have IPython commands like `%timeit`
-4. `pip install 'allowed[all]'` if you want to
-   check method calls and notebook cells with IPython commands
+but should preferably be installed in a new or existing virtual environment,
+e.g. the one for the course you are studying or teaching.
+A virtual environment is a folder with the software you need for one or more projects.
+This helps ensuring that you always use the right versions of the right packages for
+each project.
 
-If you're using Jupyter notebooks, then you will likely already have IPython installed.
-Type `pip show ipython` to check if you have it.
+1. To create a virtual environment, enter `python -m venv path/to/folder`.
 
-On Windows, you must install [WSL](https://learn.microsoft.com/en-us/windows/wsl)
-in order to be able to choose option 2 or 4, as the
-[pytype](https://google.github.io/pytype) type checker isn't available for Windows.
+The folder you indicate will be created if it doesn't exist.
+For example, if you want to keep all virtual environments in subfolders of `~/environments`,
+you would create a new virtual environment for course CS101 with
+`python -m venv ~/environments/cs101`.
+
+Virtual environments need to be activated in order install software in them.
+
+2. To activate a virtual environment enter
+   - `source path/to/folder/bin/activate` in Linux/macOS
+   - `path/to/folder/scripts/Activate` in Windows.
+
+For our example, it would be `. ~/environments/cs101/bin/activate` or
+`~/environments/cs101/scripts/Activate`.
+After activating, the command prompt becomes `(folder)`, e.g. `(cs101)`,
+to show which environment is active.
+
+You must activate a virtual environment every time you want to
+install further software into it or use the software that is installed in it.
+
+3. Once you're done using a virtual environment,
+   close the terminal/PowerShell or type `deactivate`.
+
+For more details on why one should use virtual environments and how to use them,
+we recommend reading the first two sections of
+[Real Python's tutorial](https://realpython.com/python-virtual-environments-a-primer/).
+
+### Installing
+The following instructions will install `allowed` and optional additional software
+in your current environment, whether it's the global environment or an active virtual environment
+
+1. Enter `pip install allowed`.
+
+`allowed` can check Python code in `.py` files and in `.ipynb` files (Jupyter notebooks).
+If you want to check Jupyter notebooks that have IPython commands
+like `%timeit` and `%run`, then you need IPython.
+
+2. Enter `pip show ipython` to check if your current environment has IPython installed.
+3. If you get a message that there's no such package, then enter `pip install ipython`.
+
+To check method calls of the form `variable.method(...)`, `allowed` needs
+the `pytype` package, to know the type of `variable`.
+`pytype` is only available for Linux and macOS.
+
+4. Enter `pip show pytype` to see if `pytype` is already installed.
+5. If it isn't, enter `pip install pytype`.
 
 ⇧ [Start](../README.md) | [Usage](usage.md) ⇨

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,7 +20,7 @@ check one file at a time and store the report in a text file, e.g.
 allowed path/to/file.py > disallowed.txt
 ```
 Another way to shorten the list of reported constructs is to report only
-the first occurrence in each file, using option `-f` or `--first`, e.g.
+the first occurrence in each file, using option `-f` or `--first`:
 ```bash
 allowed -f path/to/file.py path/to/notebook.ipynb
 ```
@@ -74,15 +74,10 @@ we must know the type of `variable`. For that purpose, `allowed` uses
 the `pytype` type checker, if it's installed and the Python version is 3.10.
 
 By default, `allowed` does _not_ check method calls because it slows down the process.
-You can enable these checks with option `-m` or `--methods`.
-The option can appear anywhere after `allowed` and in either form.
-For example, the following two commands are equivalent:
+You can enable these checks with option `-m` or `--methods`:
 ```bash
-allowed -m file1.py file2.py
-allowed file1.py --methods file2.py
+allowed -m file1.py notebook.ipynb
 ```
-Note that the second command checks the method calls in _both_ files,
-not just in the second file.
 
 ### Ignoring specific lines
 
@@ -114,10 +109,8 @@ However, if the file name starts with a number that isn't the intended unit,
 you must provide it,
 e.g. if the file name starts with the number of the assignment, not of the unit:
 ```bash
-allowed 01_submission.py --unit 5
+allowed --unit 5 01_submission.py
 ```
-As this example shows, the unit option can appear
-anywhere after `allowed` and in either form.
 
 ### Checking notebooks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "allowed"
-version = "1.3.dev6" # as in allowed.py
+version = "1.3dev7" # as in allowed.py
 description = "Check if a program only uses a subset of the Python language."
 authors = ["Michel Wermelinger <michel.wermelinger@open.ac.uk>"]
 readme = "README.md"
@@ -17,20 +17,14 @@ classifiers = [
     ]
 
 [tool.poetry.dependencies]
-# use same versions as m269-installer
-python = "~3.10"
-ipython = {version = "8.13.1", optional = true}
-pytype = {version = "2023.04.27", optional = true, markers = "platform_system != 'Windows'"}
-
-[tool.poetry.extras]
-pytype = ["pytype"]
-ipython = ["ipython"]
-all = ["ipython", "pytype"]
+python = "^3.10"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.1.11"
 mypy = "^1.8.0"
 bandit = "^1.7.6"
+ipython = "^8.13.1"
+pytype = {version = ">=2023.04.27", markers = "platform_system != 'Windows'"}
 
 [tool.poetry.scripts]
 allowed = "allowed.allowed:main"

--- a/tests/folder-first.txt
+++ b/tests/folder-first.txt
@@ -20,21 +20,21 @@ allowed/allowed.py:8: os
 allowed/allowed.py:9: re
 allowed/allowed.py:10: sys
 allowed/allowed.py:11: pathlib
-allowed/allowed.py:15: try
-allowed/allowed.py:16: pytype
-allowed/allowed.py:17: pytype.tools.annotate_ast
-allowed/allowed.py:26: IPython.core.inputtransformer2
-allowed/allowed.py:128: dict comprehension
-allowed/allowed.py:263: if expression
-allowed/allowed.py:280: f-string
-allowed/allowed.py:292: :=
-allowed/allowed.py:293: int()
-allowed/allowed.py:389: hasattr()
-allowed/allowed.py:408: isinstance()
-allowed/allowed.py:413: type()
-allowed/allowed.py:503: with
-allowed/allowed.py:585: global
-allowed/allowed.py:638: break
-allowed/allowed.py:639: for-else
+allowed/allowed.py:13: try
+allowed/allowed.py:14: pytype
+allowed/allowed.py:15: pytype.tools.annotate_ast
+allowed/allowed.py:22: IPython.core.inputtransformer2
+allowed/allowed.py:123: dict comprehension
+allowed/allowed.py:258: if expression
+allowed/allowed.py:275: f-string
+allowed/allowed.py:287: :=
+allowed/allowed.py:288: int()
+allowed/allowed.py:384: hasattr()
+allowed/allowed.py:403: isinstance()
+allowed/allowed.py:408: type()
+allowed/allowed.py:498: with
+allowed/allowed.py:580: global
+allowed/allowed.py:630: break
+allowed/allowed.py:631: for-else
 WARNING: didn't check method calls (use option -m)
 WARNING: each construct was reported once; other occurrences may exist


### PR DESCRIPTION
- Removed version checks to run with Python > 3.10.
- Fixed 3.10 target language for pytype, because it doesn't handle yet 3.12 and older versions don't handle 3.11.
- Updated installation instructions.
- Moved pytype and ipython to developer dependencies, but haven't done new poetry install. 

Checked on macOS with fresh venvs with Python 3.11 and 3.12 and then a local installation:`pip install path/to/dsa-ou/allowed`. Seems to work with and without ipython and pytype. 

Could you please check on Windows and Linux? Thanks.