### PR TITLE
Fix #62: add verbose option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This project does *not* adhere to [Semantic Versioning](https://semver.org).
 ## [Unreleased](https://github.com/dsa-ou/allowed/compare/v1.3.0...HEAD)
 These changes are in the GitHub repository but not on [PyPI](https://pypi.org/project/allowed).
 
+### Added
+- option `-v`/ `--verbose`: display additional info about the checking process
+
 ### Fixed
 - report syntax errors in notebooks in the same way as in Python files
 

--- a/allowed/allowed.py
+++ b/allowed/allowed.py
@@ -722,14 +722,28 @@ def main() -> None:
 
     if args.verbose:
         print(
-            f"INFO: found {issues} unknown constructs in",
-            f"{py_checked} .py and {nb_checked} .ipynb files",
+            "INFO: checked",
+            f"{py_checked} Python file{'' if py_checked == 1 else 's'} and",
+            f"{nb_checked} notebook{'' if nb_checked == 1 else 's'}",
         )
+        if issues:
+            print(
+                f"INFO: the {issues} Python construct{'s' if issues > 1 else ''}",
+                f"listed above {'are' if issues > 1 else 'is'} not allowed",
+            )
+        elif nb_checked or py_checked:
+            print("INFO: found no disallowed Python constructs")
         if unchecked:
             print(
-                f"INFO: didn't process {unchecked} files due to syntax or other errors"
+                f"INFO: didn't check {unchecked} Python",
+                f"file{'s' if unchecked > 1 else ''} or notebook{'s' if unchecked > 1 else ''}",
+                "due to syntax or other errors",
             )
-
+    if args.first and issues:
+        print(
+            "WARNING:",
+            "other occurrences of the listed constructs may exist (don't use option -f)",  # noqa: E501
+        )
     if (py_checked or nb_checked) and not args.methods:
         print(
             "WARNING: didn't check method calls",
@@ -739,8 +753,6 @@ def main() -> None:
         print(
             "WARNING: didn't check notebook cells with %-commands (IPython not installed)"  # noqa: E501
         )
-    if (py_checked or nb_checked) and args.first:
-        print("WARNING: each construct was reported once; other occurrences may exist")
 
 
 if __name__ == "__main__":

--- a/allowed/allowed.py
+++ b/allowed/allowed.py
@@ -288,12 +288,12 @@ def check_imports() -> str:
 # ----- auxiliary functions -----
 
 
-def show_units(filename: str, last_unit: int):
+def show_units(filename: str, last_unit: int) -> None:
     """Print a message about the units being checked."""
     if last_unit == 1:
         units = "unit 1"
     elif last_unit > 0:
-        units = f"units 1–{last_unit}"
+        units = f"units 1–{last_unit}"  # noqa: RUF001 (it's an en-dash)
     else:
         units = "all units"
     print(f"INFO: checking {filename} against {units}")
@@ -546,7 +546,9 @@ def check_file(
                     print(f"{filename}:cell_{cell}:{line}: {message}")
                 else:
                     print(f"{filename}:{line}: {message}")
-                issues += 1
+                # don't count syntax errors as unknown constructs
+                if "ERROR" not in message:
+                    issues += 1
                 if report_first and "ERROR" not in message:
                     messages.add(message)
                 last_error = (cell, line, message)
@@ -720,7 +722,8 @@ def main() -> None:
 
     if args.verbose:
         print(
-            f"INFO: found {issues} unknown constructs in {py_checked} .py and {nb_checked} .ipynb files"
+            f"INFO: found {issues} unknown constructs in",
+            f"{py_checked} .py and {nb_checked} .ipynb files",
         )
         if unchecked:
             print(

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -67,6 +67,11 @@ was _not_ checked, for these reasons:
 - `UNICODE ERROR`: the file has some strange characters and couldn't be read
 - `VALUE ERROR`: some other cause; please report it to us.
 
+When the command line option `-v` or `--verbose` is given,
+the tool outputs additional information, including
+the total number of files processed and of unknown constructs found, and
+the total number of files not processed due to syntax, format or other errors.
+
 ### Extra checks
 
 To check method calls of the form `variable.method(...)`,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -120,7 +120,7 @@ allowed --unit 5 01_submission.py
 ### Checking notebooks
 
 As mentioned earlier, `allowed` does check Jupyter notebooks and
-reports the cells and lines with disallowed constructs: `notebook.ipynb:cell_13:5: ...`
+reports the cells and lines with unknown constructs: `notebook.ipynb:cell_13:5: ...`
 means that line 5 of the 13th code cell uses a construct that wasn't taught.
 
 If a code cell has invalid Python, `allowed` reports a syntax error and
@@ -131,5 +131,8 @@ the commands are transformed into Python code and the cell is checked,
 if it hasn't other syntax errors.
 The transformed commands use function calls and attributes, so
 the cell will only pass the check if those Python constructs are allowed.
+
+In the verbose output (option `-v` / `--verbose`), syntax errors do not count
+towards the unknown constructs total.
 
 ⇦ [Installation](installation.md) | ⇧ [Start](../README.md) | [Configuration](configuration.md) ⇨

--- a/tests/folder-first.txt
+++ b/tests/folder-first.txt
@@ -20,22 +20,22 @@ allowed/allowed.py:8: os
 allowed/allowed.py:9: re
 allowed/allowed.py:10: sys
 allowed/allowed.py:11: pathlib
-allowed/allowed.py:13: try
-allowed/allowed.py:14: pytype
-allowed/allowed.py:15: pytype.tools.annotate_ast
-allowed/allowed.py:22: IPython.core.inputtransformer2
-allowed/allowed.py:123: dict comprehension
-allowed/allowed.py:259: if expression
-allowed/allowed.py:276: f-string
-allowed/allowed.py:288: :=
-allowed/allowed.py:289: int()
-allowed/allowed.py:385: hasattr()
-allowed/allowed.py:407: isinstance()
-allowed/allowed.py:412: type()
-allowed/allowed.py:507: global
-allowed/allowed.py:510: with
-allowed/allowed.py:645: break
-allowed/allowed.py:646: for-else
-allowed/allowed.py:653: raise
+allowed/allowed.py:18: try
+allowed/allowed.py:19: pytype
+allowed/allowed.py:20: pytype.tools.annotate_ast
+allowed/allowed.py:27: IPython.core.inputtransformer2
+allowed/allowed.py:128: dict comprehension
+allowed/allowed.py:264: if expression
+allowed/allowed.py:281: f-string
+allowed/allowed.py:304: :=
+allowed/allowed.py:305: int()
+allowed/allowed.py:401: hasattr()
+allowed/allowed.py:420: isinstance()
+allowed/allowed.py:425: type()
+allowed/allowed.py:525: global
+allowed/allowed.py:528: with
+allowed/allowed.py:681: break
+allowed/allowed.py:682: for-else
+allowed/allowed.py:689: raise
 WARNING: didn't check method calls (use option -m)
 WARNING: each construct was reported once; other occurrences may exist

--- a/tests/folder-first.txt
+++ b/tests/folder-first.txt
@@ -1,3 +1,5 @@
+INFO: using configuration /Users/mw4687/GitHub/dsa-ou/allowed/allowed/m269.json
+INFO: checking tests/sample.ipynb against all units
 tests/sample.ipynb:cell_1:2: SYNTAX ERROR: '(' was never closed
 tests/sample.ipynb:cell_2:4: types
 tests/sample.ipynb:cell_2:5: choice
@@ -12,7 +14,10 @@ tests/sample.ipynb:cell_6:4: f-string
 tests/sample.ipynb:cell_6:9: <<
 tests/sample.ipynb:cell_6:10: math.e
 tests/sample.ipynb:cell_6:11: type()
+INFO: checking allowed/__init__.py against all units
+INFO: checking allowed/__main__.py against all units
 allowed/__main__.py:1: allowed
+INFO: checking allowed/allowed.py against all units
 allowed/allowed.py:5: argparse
 allowed/allowed.py:6: ast
 allowed/allowed.py:7: json
@@ -34,8 +39,10 @@ allowed/allowed.py:420: isinstance()
 allowed/allowed.py:425: type()
 allowed/allowed.py:525: global
 allowed/allowed.py:528: with
-allowed/allowed.py:681: break
-allowed/allowed.py:682: for-else
-allowed/allowed.py:689: raise
+allowed/allowed.py:682: break
+allowed/allowed.py:683: for-else
+allowed/allowed.py:690: raise
+INFO: checked 3 Python files and 1 notebook
+INFO: the 38 Python constructs listed above are not allowed
+WARNING: other occurrences of the listed constructs may exist (don't use option -f)
 WARNING: didn't check method calls (use option -m)
-WARNING: each construct was reported once; other occurrences may exist

--- a/tests/foobar-hfm.txt
+++ b/tests/foobar-hfm.txt
@@ -1,4 +1,4 @@
-usage: allowed [-h] [-V] [-f] [-m] [-u UNIT] [-c CONFIG]
+usage: allowed [-h] [-V] [-f] [-m] [-u UNIT] [-c CONFIG] [-v]
                file_or_folder [file_or_folder ...]
 
 Check that the code only uses certain constructs. See http://dsa-
@@ -18,3 +18,4 @@ options:
   -c CONFIG, --config CONFIG
                         allow the constructs given in CONFIG (default:
                         m269.json)
+  -v, --verbose         show additional info as files are processed

--- a/tests/invalid-py.txt
+++ b/tests/invalid-py.txt
@@ -1,2 +1,1 @@
 tests/invalid.py:2: SYNTAX ERROR: '(' was never closed
-WARNING: didn't check method calls (use option -m)

--- a/tests/invalid-py.txt
+++ b/tests/invalid-py.txt
@@ -1,1 +1,5 @@
+INFO: using configuration /Users/mw4687/GitHub/dsa-ou/allowed/allowed/m269.json
+INFO: checking tests/invalid.py against units 1–3
 tests/invalid.py:2: SYNTAX ERROR: '(' was never closed
+INFO: checked 0 Python files and 0 notebooks
+INFO: didn't check 1 Python file or notebook due to syntax or other errors

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -21,8 +21,8 @@ elif [ $1 = "run" ]; then
     echo; echo "-c invalid.json"; echo "---"
     $cmd -c tests/invalid.json foobar | diff -w - tests/invalid-c.txt
     # check with invalid Python code
-    echo; echo "invalid.py"; echo "---"
-    $cmd tests/invalid.py | diff -w - tests/invalid-py.txt
+    echo; echo "-v -u 3 invalid.py"; echo "---"
+    $cmd -v -u 3 tests/invalid.py | diff -w - tests/invalid-py.txt
     # check the example code and notebook
     echo; echo "sample.py"; echo "---"
     $cmd tests/sample.py | diff -w - tests/sample-py.txt
@@ -40,12 +40,12 @@ elif [ $1 = "create" ]; then
     $cmd tests/invalid.ipynb > tests/invalid-nb.txt
     $cmd -c tests/sample.py foobar > tests/sample-c.txt
     $cmd -c tests/invalid.json foobar > tests/invalid-c.txt
-    $cmd tests/invalid.py > tests/invalid-py.txt
+    $cmd -v -u 3 tests/invalid.py > tests/invalid-py.txt
     $cmd tests/sample.py > tests/sample-py.txt
     $cmd tests/sample.py -m > tests/sample-py-m.txt
     $cmd tests/sample.ipynb > tests/sample-nb.txt
     $cmd tests/sample.ipynb -m > tests/sample-nb-m.txt
-    $cmd -f tests/sample.ipynb allowed > tests/folder-first.txt
+    $cmd -vf tests/sample.ipynb allowed > tests/folder-first.txt
 else
     echo "Usage: ./tests.sh [run|create]"
 fi

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -32,8 +32,8 @@ elif [ $1 = "run" ]; then
     $cmd tests/sample.ipynb | diff -w - tests/sample-nb.txt
     echo; echo "sample.ipynb -m"; echo "---"
     $cmd tests/sample.ipynb -m | diff -w - tests/sample-nb-m.txt
-    echo; echo "-f sample.ipynb allowed/"; echo "---"
-    $cmd -f tests/sample.ipynb allowed | diff -w - tests/folder-first.txt
+    echo; echo "-vf sample.ipynb allowed/"; echo "---"
+    $cmd -vf tests/sample.ipynb allowed | diff -w - tests/folder-first.txt
 elif [ $1 = "create" ]; then
     $cmd foobar -fm > tests/foobar-fm.txt
     $cmd foobar -hfm > tests/foobar-hfm.txt


### PR DESCRIPTION
The new option reports:
- full pathname of config file
- units checked for each file
- total number of files checked and issues found
- total number of files skipped due to errors

Let me know if any other thing should be reported, but I think the above covers most things needed for debugging and knowing that a file was processed but has no errors.

The info is sent to stdout and I don't think algoesup will catch it because none of it is of the form `filename:line: ...`. If students want reassurance that the cell was checked, then probably need a more generic approach in algoesup that prints `allowed|ruff|pytype found no issues` if no error message is matched.
