### PR TITLE
Fix #76: check methods in Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ This project does *not* adhere to [Semantic Versioning](https://semver.org).
 ## [Unreleased](https://github.com/dsa-ou/allowed/compare/v1.5.1...HEAD)
 These changes are in the GitHub repository but not on [PyPI](https://pypi.org/project/allowed).
 
-Nothing yet.
+<!-- Nothing yet. -->
+### Fixed
+- option `-m` now works with Python 3.12 and most recent pytype
 
 ## [1.5.1](https://github.com/dsa-ou/allowed/compare/v1.5.0...v1.5.1) - 2024-09-10
 ### Fixed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,7 @@ means that unit 2 introduces names (identifiers), the plus operator and the buil
 For the possible syntactical elements, see dictionary `SYNTAX` in
 [`allowed.py`](https://github.com/dsa-ou/allowed/blob/main/allowed/allowed.py).
 For the possible built-in functions, see set `BUILTINS` in the same file.
+Only a subset of the Python 3.10 language is currently supported.
 
 The various uses of a construct can't be individually allowed or disallowed.
 For example, you can't allow integer addition

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -123,9 +123,17 @@ make lint
 ```bash
 make run_tests
 ```
-> This command runs all the project's tests.
-> Some of the tests check the behaviour of `allowed` without IPython or pytype.
-> For that, they require your global environment to _not_ have those packages installed.
+> This command runs some tests within the created Poetry environment
+> and other tests in the current environment. The latter will only pass if
+> your environment has Python 3.10 to 3.12 installed but _not_ IPython or pytype.
+
+If you have a virtual environment with a specific version of Python and pytype
+you want to test, activate that environment and then type
+```bash
+tests/tests.sh run
+```
+> This executes the same tests as for the Poetry environment, but runs them
+> in the current environment instead.
 
 Be sure to resolve any errors that arise before moving on to the next step.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ with `allowed` installed, then you may skip this section.
 2. Enter `python -V` to check the version you have installed.
 3. If it's 3.9 or earlier, [download and install](https://www.python.org/downloads)
    the latest version.
-   However, to use `pytype` (see below) you must install Python 3.10 or 3.11.
+   However, to use `pytype` (see below) you must install Python 3.10 to 3.12.
 
 ### Virtual environments
 Like any other Python package, `allowed` can be installed in your default global environment,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -76,7 +76,7 @@ the total number of files not processed due to syntax, format or other errors.
 
 To check method calls of the form `variable.method(...)`,
 we must know the type of `variable`. For that purpose, `allowed` uses
-the `pytype` type checker, if it's installed and the Python version is 3.10 or 3.11.
+the `pytype` type checker, if it's installed and the Python version is 3.10 to 3.12.
 
 By default, `allowed` does _not_ check method calls because it slows down the process.
 You can enable these checks with option `-m` or `--methods`:

--- a/tests/folder-first.txt
+++ b/tests/folder-first.txt
@@ -149,20 +149,20 @@ allowed/allowed.py:11: pathlib
 allowed/allowed.py:22: try
 allowed/allowed.py:23: pytype
 allowed/allowed.py:24: pytype.tools.annotate_ast
-allowed/allowed.py:34: IPython.core.inputtransformer2
-allowed/allowed.py:135: dict comprehension
-allowed/allowed.py:271: if expression
-allowed/allowed.py:288: f-string
-allowed/allowed.py:316: :=
-allowed/allowed.py:317: int()
-allowed/allowed.py:413: hasattr()
-allowed/allowed.py:432: isinstance()
-allowed/allowed.py:437: type()
-allowed/allowed.py:537: global
-allowed/allowed.py:540: with
-allowed/allowed.py:709: break
-allowed/allowed.py:710: for-else
-allowed/allowed.py:717: raise
+allowed/allowed.py:37: IPython.core.inputtransformer2
+allowed/allowed.py:138: dict comprehension
+allowed/allowed.py:276: if expression
+allowed/allowed.py:293: f-string
+allowed/allowed.py:321: :=
+allowed/allowed.py:322: int()
+allowed/allowed.py:420: hasattr()
+allowed/allowed.py:439: isinstance()
+allowed/allowed.py:444: type()
+allowed/allowed.py:546: global
+allowed/allowed.py:549: with
+allowed/allowed.py:718: break
+allowed/allowed.py:719: for-else
+allowed/allowed.py:726: raise
 INFO: checked 8 Python files and 1 notebook
 INFO: the 150 Python constructs listed above are not allowed
 INFO: didn't check 2 Python files or notebooks due to syntax or other errors


### PR DESCRIPTION
- configure pytype for 3.10 or 3.11 to avoid crashing on comprehensions
- normalise typenames like List so that configuration and pytype always match
- update the test that runs `allowed` on itself